### PR TITLE
Fix call to .length on undefined

### DIFF
--- a/server/src/parseError.ts
+++ b/server/src/parseError.ts
@@ -17,7 +17,10 @@ export function parseErrors(docText: string, errorStrings: string[]): ITsqlLintE
 
         const line = positionArr[0] - 1;
         const colStart = lineStarts[line];
-        const colEnd = lines[line].length;
+        var colEnd = 0;
+        if (lines[line]) {
+            colEnd = lines[line].length;
+        }
         const range: Range = {
             start: {line, character: colStart},
             end: {line, character: colEnd},


### PR DESCRIPTION
The error was not handled and would cause the extension to crash within vscode/azure data studio, eventually leading to the extension being unloaded. This change seems to at least prevent the forced unloading.