### PR TITLE
Clamp minimum line number index to 0

### DIFF
--- a/server/src/parseError.ts
+++ b/server/src/parseError.ts
@@ -15,7 +15,7 @@ export function parseErrors(docText: string, errorStrings: string[]): ITsqlLintE
         const positionStr: string = validationError[0].replace("(", "").replace(")", "");
         const positionArr: number[] = positionStr.split(",").map(Number);
 
-        const line = positionArr[0] - 1;
+        const line = Math.max(positionArr[0] - 1, 0);
         const colStart = lineStarts[line];
         const colEnd = lines[line].length;
         const range: Range = {


### PR DESCRIPTION
Some rules, such as those that check for the existence of a pattern in a script, may report a line number of 0 when no line number can be assigned. This causes a crash in the extension, which leads to the extension restarting and crash looping until it's disabled.

This change limits the minimum line number to 0 to prevent attempting to index into position -1 of the lines array.