### PR TITLE
feat: closed #55 by adding var-autocomplete and var-renaming features.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,8 +1,9 @@
 "use strict";
 
 import * as path from "path";
-import { workspace, ExtensionContext, window, TextEdit, commands  } from "vscode";
+import { workspace, ExtensionContext, window, TextEdit, commands } from "vscode";
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from "vscode-languageclient/node";
+import { registerVarAutocomplete } from "./varAutocomplete";
 
 let client: LanguageClient;
 
@@ -29,7 +30,7 @@ export function activate(context: ExtensionContext) {
   client.registerProposedFeatures();
 
   function fix() {
-    client.sendNotification("fix", window.activeTextEditor.document.uri.toString() );
+    client.sendNotification("fix", window.activeTextEditor.document.uri.toString());
   }
 
   function applyTextEdits(uri: string, documentVersion: number, edits: TextEdit[]) {
@@ -54,6 +55,10 @@ export function activate(context: ExtensionContext) {
       });
     }
   }
+
+  // VAR AUTOCOMPLETE sugar feature. Comment this line if you want to disable
+  registerVarAutocomplete(context);
+
   context.subscriptions.push(
     client.start(),
     commands.registerCommand("_tsql-lint.change", applyTextEdits),

--- a/client/src/varAutocomplete.ts
+++ b/client/src/varAutocomplete.ts
@@ -1,0 +1,174 @@
+"use strict";
+
+import {
+    ExtensionContext,
+    languages,
+    CompletionItem,
+    CompletionItemKind,
+    Range,
+    WorkspaceEdit,
+} from "vscode";
+
+/**
+ * For the fellow maintainers:
+ * 
+ * Register `variable autocomplete and rename` providers for SQL `@variables`
+ * 
+ * Case example:
+ * ```sql
+ * DECLARE \@something VARCHAR(10)
+ * DECLARE \@someone VARCHAR(10)
+ * DECLARE \@nothing VARCHAR(10)
+ * 
+ * -- some random queries
+ * SELECT \@some -- expected: will suggest \@something and \@someone
+ * 
+ * -- lets say you select \@someone , pressing F2 (refactor/rename)
+ * -- will rename all variables in current document with same name.
+ * ```
+ * 
+ * Comment out the function call in [extension.ts] `activate()` to disable 
+ * this feature in case this do break something and you don't have so much
+ * time to fix.
+ * 
+ * after all, this is just a sugar add-on, nice to keep AS LONG AS the main
+ * extension feature doesn't break. I tested and it works fine locally, but
+ * doesn't guarantee it's fully safe for the publishing. (tbh still figuring
+ * out what some other parts of the code are doing. this ext is amazing!) --ideeyn
+ */
+export function registerVarAutocomplete(context: ExtensionContext): void {
+    // =========================================================
+    // AUTOCOMPLETE - Variable completions for @variables
+    // =========================================================
+    const completionProvider = languages.registerCompletionItemProvider(
+        ["sql", "mssql"],
+        {
+            provideCompletionItems(document, position) {
+                const line = document.lineAt(position.line).text;
+
+                const startMatch = line
+                    .substring(0, position.character)
+                    .match(/@[a-zA-Z_0-9]*$/);
+
+                const endMatch = line
+                    .substring(position.character)
+                    .match(/^[a-zA-Z_0-9]*/);
+
+                const startText = startMatch ? startMatch[0] : "@";
+                const endText = endMatch ? endMatch[0] : "";
+
+                /// NOTE: this one will suggest all in entire document, dont care is it BEFORE or AFTER cursor.
+                /// scanning entire document:
+                // const text = document.getText();
+                // const vars = [...new Set((text.match(/@[a-zA-Z_][a-zA-Z0-9_]*/g) || []))];
+
+                /// NOTE: this one only suggest what is BEFORE CURSOR.
+                /// only consider text before the current word:
+                const currentWordStart = position.character - startText.length;
+                const textBeforeCursor = document.getText(
+                    new Range(0, 0, position.line, currentWordStart)
+                );
+                const vars = [...new Set(
+                    (textBeforeCursor.match(/@[a-zA-Z_][a-zA-Z0-9_]*/g) || []),
+                )];
+
+                const current = startText.toLowerCase();
+
+                return vars
+                    .filter(v => v.toLowerCase().startsWith(current))
+                    .map((v) => {
+                        const item = new CompletionItem(
+                            v,
+                            CompletionItemKind.Variable,
+                        );
+
+                        item.range = new Range(
+                            position.line,
+                            position.character - startText.length,
+                            position.line,
+                            position.character + endText.length,
+                        );
+
+                        item.insertText = v;
+
+                        return item;
+                    });
+            },
+        },
+        "@",
+    );
+
+    // =========================================================
+    // F2 RENAME - Rename @variables with hidden @ UX
+    // =========================================================
+    const renameProvider = languages.registerRenameProvider(
+        ["sql", "mssql"],
+        {
+            prepareRename(document, position) {
+                const range = document.getWordRangeAtPosition(
+                    position,
+                    /@[a-zA-Z_][a-zA-Z0-9_]*/,
+                );
+
+                if (!range) {
+                    return null;
+                }
+
+                const text = document.getText(range);
+
+                // hide @ in rename UI
+                return {
+                    range: new Range(
+                        range.start.translate(0, 1),
+                        range.end,
+                    ),
+                    placeholder: text.substring(1),
+                };
+            },
+
+            provideRenameEdits(document, position, newName) {
+                const wordRange = document.getWordRangeAtPosition(
+                    position,
+                    /@[a-zA-Z_][a-zA-Z0-9_]*/,
+                );
+
+                if (!wordRange) {
+                    return null;
+                }
+
+                const oldName = document.getText(wordRange);
+
+                const finalName = newName.startsWith("@")
+                    ? newName
+                    : "@" + newName;
+
+                const text = document.getText();
+
+                const escaped = oldName.replace(
+                    /[.*+?^${}()|[\]\\]/g,
+                    "\\$&",
+                );
+
+                const regex = new RegExp(escaped, "g");
+
+                const edit = new WorkspaceEdit();
+
+                for (const match of text.matchAll(regex)) {
+                    const start = document.positionAt(match.index);
+                    const end = document.positionAt(match.index + oldName.length);
+
+                    edit.replace(
+                        document.uri,
+                        new Range(start, end),
+                        finalName,
+                    );
+                }
+
+                return edit;
+            },
+        },
+    );
+
+    context.subscriptions.push(completionProvider);
+    context.subscriptions.push(renameProvider);
+}

--- a/client/src/varAutocomplete.ts
+++ b/client/src/varAutocomplete.ts
@@ -10,31 +10,12 @@ import {
 } from "vscode";
 
 /**
- * For the fellow maintainers:
- * 
- * Register `variable autocomplete and rename` providers for SQL `@variables`
- * 
- * Case example:
- * ```sql
- * DECLARE \@something VARCHAR(10)
- * DECLARE \@someone VARCHAR(10)
- * DECLARE \@nothing VARCHAR(10)
- * 
- * -- some random queries
- * SELECT \@some -- expected: will suggest \@something and \@someone
- * 
- * -- lets say you select \@someone , pressing F2 (refactor/rename)
- * -- will rename all variables in current document with same name.
- * ```
- * 
- * Comment out the function call in [extension.ts] `activate()` to disable 
- * this feature in case this do break something and you don't have so much
- * time to fix.
- * 
- * after all, this is just a sugar add-on, nice to keep AS LONG AS the main
- * extension feature doesn't break. I tested and it works fine locally, but
- * doesn't guarantee it's fully safe for the publishing. (tbh still figuring
- * out what some other parts of the code are doing. this ext is amazing!) --ideeyn
+ * Registers variable autocomplete and rename providers for SQL @variables.
+ *
+ * Autocomplete suggests @variables declared earlier in the document.
+ * F2 rename renames all occurrences of the variable in the current file.
+ *
+ * To disable, comment out the registerVarAutocomplete() call in extension.ts.
  */
 export function registerVarAutocomplete(context: ExtensionContext): void {
     // =========================================================
@@ -57,13 +38,7 @@ export function registerVarAutocomplete(context: ExtensionContext): void {
                 const startText = startMatch ? startMatch[0] : "@";
                 const endText = endMatch ? endMatch[0] : "";
 
-                /// NOTE: this one will suggest all in entire document, dont care is it BEFORE or AFTER cursor.
-                /// scanning entire document:
-                // const text = document.getText();
-                // const vars = [...new Set((text.match(/@[a-zA-Z_][a-zA-Z0-9_]*/g) || []))];
-
-                /// NOTE: this one only suggest what is BEFORE CURSOR.
-                /// only consider text before the current word:
+                // Only suggest variables declared before the cursor position.
                 const currentWordStart = position.character - startText.length;
                 const textBeforeCursor = document.getText(
                     new Range(0, 0, position.line, currentWordStart)
@@ -149,7 +124,11 @@ export function registerVarAutocomplete(context: ExtensionContext): void {
                     "\\$&",
                 );
 
-                const regex = new RegExp(escaped, "g");
+                // "gi" for case-insensitive matching: T-SQL variable references are
+                // case-insensitive (@myVar and @MYVAR are the same variable).
+                // Note: this operates on raw document text, so occurrences inside
+                // string literals or comments will also be renamed.
+                const regex = new RegExp(escaped, "gi");
 
                 const edit = new WorkspaceEdit();
 


### PR DESCRIPTION
This pull request is created based on issue #55 . A lightweight sugar feature. 

I tested this locally and things seems fine. But yes, better if someone can also test. I make a narrow contact point in `extenstion.ts` so maintainers can toggle it on/off easily just in case. I don't touch anywhere else, should be an easy merge (with a test just to make sure, maybe)

Thankyou for the review and the time!